### PR TITLE
Suppress E_NOTICE error on string comparison

### DIFF
--- a/testmore.php
+++ b/testmore.php
@@ -119,7 +119,7 @@ function ok($pass, $test_name = '')
         $test_name = "- $test_name";
     }
     
-    if ($test_name[0] != '#' and isset($_testmore_todo) and count($_testmore_todo)) {
+    if (substr($test_name, 0, 1) != '#' and isset($_testmore_todo) and count($_testmore_todo)) {
         $msg = array_pop( array_values( $_testmore_todo ) );
         $test_name .= " # TODO $msg";
     }


### PR DESCRIPTION
Slower comparison, but functional and the speed hit should not be significant in any reasonable use case. More readable than most potential substitutes.

Addresses "PHP Notice:  Uninitialized string offset: 0 in /my/path/testmore/testmore.php on line 122"
